### PR TITLE
Update build test

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -59,10 +59,6 @@ jobs:
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
     - name: Run staticcheck
       run: staticcheck ./...
-    - name: Install golint
-      run: go install golang.org/x/lint/golint@latest
-    - name: Run golint
-      run: golint ./...
     - name: Install gotestsum
       run: go install gotest.tools/gotestsum@latest
     - name: Run tests

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -63,8 +63,10 @@ jobs:
       run: go install golang.org/x/lint/golint@latest
     - name: Run golint
       run: golint ./...
+    - name: Install gotestsum
+      run: go install gotest.tools/gotestsum@latest
     - name: Run tests
-      run: go test -race -coverprofile=cover.out -covermode=atomic -vet=off ./...
+      run: gotestsum -- -race -coverprofile=cover.out -covermode=atomic -vet=off ./...
     - name: Quality Gate      
       run: |
         total=`go tool cover -func=cover.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`


### PR DESCRIPTION
This PR updates the test step to use [gotestsum](https://github.com/gotestyourself/gotestsum) for nicer output.

It also removes the linting step since:
> NOTE: Golint is  [deprecated](https://github.com/golang/go/issues/38968). There's no drop-in replacement for it, but tools such as [Staticcheck](https://staticcheck.io/) and go vet should be used instead.