### PR TITLE
Use private repo key and add push image workflow

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -1,13 +1,19 @@
 on:
   workflow_call:
     secrets:
-      SLACK_BOT_TOKEN: 
+      SLACK_BOT_TOKEN:
+        required: true
+      GO_PRIVATE_REPO_KEY:
         required: true
     inputs:
       coverage_threshold:
         type: number
         required: false
         default: 75.0
+    outputs:
+      short_sha:
+        description: "Short version of the git commit SHA"
+        value: ${{ jobs.build.outputs.shortsha }}
 
 jobs:
   build:
@@ -41,29 +47,64 @@ jobs:
         image: redis:5.0.14
         ports:
           - "6379:6379"
+    env:
+      POSTGRES_URI: "postgres://localhost:5432/postgres?user=postgres&password=postgres&sslmode=disable"
+      POSTGRES_MIGRATIONS: ../../db/migrations/postgres
+      CASSANDRA_CLUSTER_HOSTS: localhost
+      CASSANDRA_PORT: 9042
+      CASSANDRA_KEYSPACE: svc_test
+      CASSANDRA_MIGRATIONS: ../../db/migrations/cassandra
+      CASSANDRA_PASSWORD: cassandra
+      CASSANDRA_USER: cassandra
+      GOPRIVATE: github.com/toggleglobal/*
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+    outputs:
+      shortsha: ${{ steps.extract_info.outputs.shortsha }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Extract Info
+      id: extract_info
+      run: |
+        echo "::set-output name=shortsha::$(git rev-parse --short HEAD)"
+
+    - name: Setup SSH and git
+      run: |
+        mkdir -p -m 0700 "$HOME/.ssh"
+        ssh-keyscan -H github.com >> $HOME/.ssh/known_hosts
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add - <<< "${{ secrets.GO_PRIVATE_REPO_KEY }}"
+        git config --global url."git@github.com:toggleglobal".insteadOf https://github.com/toggleglobal
+
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
         go-version: 1.17.3
         check-latest: false
+
     - name: Verify dependencies
       run: go mod verify
+
     - name: Build
       run: go build -v ./...
+
     - name: Run go vet
       run: go vet ./...
+
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
     - name: Run staticcheck
       run: staticcheck ./...
+
     - name: Install gotestsum
       run: go install gotest.tools/gotestsum@latest
+
     - name: Run tests
-      run: gotestsum -- -race -coverprofile=cover.out -covermode=atomic -vet=off ./...
-    - name: Quality Gate      
+      run: gotestsum --no-color=false -- -race -coverprofile=cover.out -covermode=atomic -vet=off ./...
+
+    - name: Quality Gate
       run: |
         total=`go tool cover -func=cover.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
         echo "Total test coverage = $total%"
@@ -71,6 +112,7 @@ jobs:
           echo "Quality gate failed. Coverage below minimum ${{ inputs.coverage_threshold }}%"
           exit 1
         fi
+
     - name: Post Success message on Slack channel
       if: success()
       uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,0 +1,71 @@
+on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+      GO_PRIVATE_REPO_KEY:
+        required: true
+
+    inputs:
+      branch:
+        description: "Name of source branch"
+        required: true
+        type: string
+      dockerfile:
+        description: "Path to the Dockerfile"
+        required: true
+        type: string
+      tags:
+        description: "List of tags (must be all lowercase)"
+        required: false
+        type: string
+
+jobs:
+  push-image:
+    name: Push Image
+    runs-on: ubuntu-latest
+    env:
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup SSH
+      run: |
+        mkdir -p -m 0700 "$HOME/.ssh"
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add - <<< "${{ secrets.GO_PRIVATE_REPO_KEY }}"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        install: true
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Info
+      run: |
+        echo "Branch: ${{inputs.branch}}"
+        echo "Tags: ${{inputs.tags}}"
+
+    - name: Build image and push to Docker Hub
+      id: docker_build
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ inputs.tags }}
+        # Safety check: Only push image for main branch
+        push: ${{ inputs.branch == 'main' }}
+        ssh: default
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}
+


### PR DESCRIPTION
This PR updates the `build-go` workflow providing the ability to build go projects that have private repo dependencies.

This is a breaking change! Any repository workflows using the previous version will need to be updated.

Previously:
```yaml
jobs:
  build:
    uses: toggleglobal/workflows/.github/workflows/build-go.yml@main
    secrets:
      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
```
Now:
```yaml
jobs:
  build:
    uses: toggleglobal/workflows/.github/workflows/build-go.yml@main
    secrets: inherit
```


In addition, a new `push-image` workflow has been added which has the ability to build docker images for projects which have private repo dependencies. The idea here is that the workflow is generic and will work with any repo regardless of the main language used. Rather than hard coding certain docker related fields, the `push-image` workflow takes inputs for the image tag(s), Dockerfile path, and the target branch. The latter being a safety feature to prevent pushing the image to dockerhub if it hasn't been created from the `main` branch, whilst still verifying that the rest of the image building process works successfully. 

A typical workflow in a calling repository might look like:
```yaml
name: build
on:
  push:
    branches:
      - '**'

jobs:
  build:
    uses: toggleglobal/workflows/.github/workflows/build-go.yml@main
    secrets: inherit
    with:
      coverage_threshold: 65

  push_image:
    needs: [build]
    uses: toggleglobal/workflows/.github/workflows/push-image.yml@main
    secrets: inherit
    with:
      branch: ${{github.ref_name}}
      dockerfile: ./docker/go/Dockerfile
      tags: |
        ${{github.repository}}:${{needs.build.outputs.short_sha}}
        ${{github.repository}}:${{github.ref_name}}-latest
```
Notice the output from the `build-go` workflow returns a short-SHA for use in one of the tags used with the docker image.

A typical Dockerfile might look like this:

 ```dockerfile
FROM golang:1.17.3 AS builder

WORKDIR /go/src/my-app
COPY . .

RUN git config --global url.git@github.com:toggleglobal.insteadOf https://github.com/toggleglobal && \
    mkdir -p -m 0600 $HOME/.ssh && \
    ssh-keyscan -H github.com >>$HOME/.ssh/known_hosts

RUN go env -w GOPRIVATE=github.com/toggleglobal/*
RUN --mount=type=ssh GOOS=linux GOARCH=amd64 go build -a --ldflags="-s" -o /my-app

FROM scratch
COPY --from=builder /jeff-test /bin/my-app

ENTRYPOINT ["/bin/my-app"]
```

