### PR TITLE
Add promote to production workflow

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -1,0 +1,42 @@
+on:
+  workflow_call:
+    secrets:
+      DEPLOYTOGGLE_TOKEN_GITHUB:
+        required: true
+
+jobs:
+  promote-to-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: "toggleglobal/apps-infrastructure"
+          token: ${{ secrets.DEPLOYTOGGLE_TOKEN_GITHUB }}
+      - name: setup git
+        run: |
+          git config --global user.email "deploy@toggle.ai"
+          git config --global user.name "Deploy Toggle"
+      - name: update image tag
+        env:
+          DEV_PATH: "./applications/dev"
+          PROD_PATH: "./applications/prod"
+        run: |
+          DEV_IMAGE=$(cat "${DEV_PATH}/${{ github.event.repository.name }}.yaml" | grep "image.tag" | awk -F "image.tag:" '{print $2}' | sed "s/ //g")
+          sed -i "s/image.tag:.*/image.tag: ${DEV_IMAGE}/g" "${PROD_PATH}/${{ github.event.repository.name }}.yaml"
+      - name: create pr
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOYTOGGLE_TOKEN_GITHUB }}
+        run: |
+          BRANCH_NAME=$(echo ${{ github.sha }} | cut -c -8)
+          git checkout -b ${BRANCH_NAME}
+          git add .
+          if git status | grep -q "Changes to be committed"
+          then
+            git commit --message "Promote to production from ${{ github.event.repository.name }}"
+            echo "Pushing git commit"
+            git push -u origin ${BRANCH_NAME}
+            echo "Creating a pull request"
+            gh pr create -t "Promote to production ${{ github.event.repository.name }}" -B "main" -b "Promote to production ${BRANCH_NAME}" -H ${BRANCH_NAME}
+          else
+            echo "No changes detected"
+          fi


### PR DESCRIPTION
This workflow will provide ability to sync dev image to prod in argo application manifest.
It requires only DEPLOYTOGGLE_TOKEN_GITHUB  secret that must contain deploy@toggle.ai user's token.

To find what service manifest need to be updated used name of repository, so we need to rename some of application manifests in apps-infrastructure  repo to make it work. 

As result of this workflow we will see new PR in [apps-infrastructure](https://github.com/toggleglobal/apps-infrastructure) repo with title  "Promote to production REPO_NAME"