### PR TITLE
Use internal version of clickhouse docker image

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -74,7 +74,7 @@ jobs:
         }
       CLICKHOUSE: >-
         "clickhouse": {
-        "image": "clickhouse/clickhouse-server:22.3",
+        "image": "toggleglobal/clickhouse-server:22.3",
         "ports":["9000:9000"],
         "options": "--health-cmd \"clickhouse status\" --health-interval 10s --health-timeout 5s --health-retries 5"
         }


### PR DESCRIPTION
This PR updates the ClickHouse docker image to use our own image.
This is necessary so we can create a one node "cluster" and run distributed and replicated tables during testing.