### PR TITLE
Add runs-as input

### DIFF
--- a/.github/workflows/image-go.yml
+++ b/.github/workflows/image-go.yml
@@ -39,11 +39,12 @@ on:
         required: false
         type: string
       runs-as:
-        description: >
-          Defines how the built image is expected to be run, e.g service or cronjob.
-          The default is service.
-        required: false
-        type: string
+        description: Defines how the built image is expected to be run, e.g service or cronjob.
+        default: service
+        type: choice
+        options:
+        - service
+        - cronjob
 
 jobs:
   build-image:

--- a/.github/workflows/image-go.yml
+++ b/.github/workflows/image-go.yml
@@ -38,6 +38,12 @@ on:
         description: Version of golang used during build if specified as argument in Dockerfile
         required: false
         type: string
+      runs-as:
+        description: >
+          Defines how the built image is expected to be run, e.g service or cronjob.
+          The default is service.
+        required: false
+        type: string
 
 jobs:
   build-image:
@@ -132,20 +138,24 @@ jobs:
         repository: "toggleglobal/apps-infrastructure"
         token: ${{ secrets.DEPLOYER_GITHUB_TOKEN }}
         path: apps-infrastructure
-        
+
     - name: Setup git
       if: inputs.push-image
       run: |
         git config --global user.email "${{ secrets.DEPLOYER_EMAIL }}"
         git config --global user.name "${{ secrets.DEPLOYER_USERNAME }}"
-        
+
     - name: Update image tag
       if: inputs.push-image
       run: |
         cd apps-infrastructure
-        CHART_VALUES_PATH="./charts/${{ github.event.repository.name }}${{env.REPOSITORY_SUFFIX}}/values"
+        if [[ ${{inputs.runs-as}} == "cronjob" ]]; then
+          CHART_VALUES_PATH="./charts/${{ github.event.repository.name }}${{env.REPOSITORY_SUFFIX}}-cronjob/values"
+        else
+          CHART_VALUES_PATH="./charts/${{ github.event.repository.name }}${{env.REPOSITORY_SUFFIX}}/values"
+        fi
         printf "common:\n  image:\n    tag: ${{env.SHORT_SHA}}\n" > "${CHART_VALUES_PATH}/image-dev.yaml"
-    
+
     - name: Commit new image
       if: inputs.push-image
       run: |

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -14,6 +14,12 @@ on:
           This is primarily for use where a repository has more than one Dockerfile. This is ignored if tags has been set.
         required: false
         type: string
+      runs-as:
+        description: >
+          Defines how the built image is expected to be run, e.g service or cronjob.
+          The default is service.
+        required: false
+        type: string
 
 jobs:
   promote-to-prod:
@@ -38,7 +44,11 @@ jobs:
       - name: update image tag prod
         run: |
           cd apps-infrastructure
-          CHART_VALUES_PATH="./charts/${{ github.event.repository.name }}${{env.REPOSITORY_SUFFIX}}/values"
+          if [[ ${{inputs.runs-as}} == "cronjob" ]]; then
+            CHART_VALUES_PATH="./charts/${{ github.event.repository.name }}${{env.REPOSITORY_SUFFIX}}-cronjob/values"
+          else
+            CHART_VALUES_PATH="./charts/${{ github.event.repository.name }}${{env.REPOSITORY_SUFFIX}}/values"
+          fi
           cp "${CHART_VALUES_PATH}/image-dev.yaml" "${CHART_VALUES_PATH}/image-prod.yaml"
       - name: create pr
         env:

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -15,11 +15,12 @@ on:
         required: false
         type: string
       runs-as:
-        description: >
-          Defines how the built image is expected to be run, e.g service or cronjob.
-          The default is service.
-        required: false
-        type: string
+        description: Defines how the built image is expected to be run, e.g service or cronjob.
+        default: service
+        type: choice
+        options:
+        - service
+        - cronjob
 
 jobs:
   promote-to-prod:


### PR DESCRIPTION
## What does this PR do?
This PR adds a `runs-as` input for `image-go` and `promote-to-prod` workflows.

## Why is this PR required?
This PR is required because all cronjobs listed in apps-infrastructure/charts have a `-cronjob` suffix and so the path does not match what the workflows are looking for.

As an example, a repository called `biscuit-baker` might contain a command line application expected to be run as a cronjob. An image would be pushed to Dockerhub under the repository of the same name (`biscuit-baker`) and then an attempt would be made to update file in apps-infrastructure located at:

`/charts/biscuit-baker/values/image-dev.yaml`

However, since the project will be run as a cronjob, it is setup in apps-infrastructure with path:

`/charts/biscuit-baker-cronjob/values/image-dev.yaml`

## Can't you just set the `repository-suffix` input to 'cronjob'?
Unfortunately not. Although it would result in the correct path for the apps-infrastructure repository, the `repository-suffix` was included to overcome issues when pushing images to Dockerhub for a multi-Dockerfile _code_ repository. For example, a `biscuits` code repository might hold two Dockerfiles; one for the main biscuits _**service**_ and another for a command line application (baker) that needs to be run as a _**cronjob**_. These are pushed to _separate_ repositories in Dockerhub,`biscuits` and `biscuits-baker` respectively. The name for the latter is formed from the code repository name and the `repository-suffix` (baker). If `repository-suffix` were 'baker-cronjob' then the Dockerhub repository would not be found because it would be looking for `biscuits-baker-cronjob`. 

As code repositories should know which images will/should be run as cronjobs, they can simply set the input `runs-as: cronjob` accordingly, which will append `-cronjob`, but only when dealing with apps-infrastructure. 

  
   