### PR TITLE
Pinned staticcheck to v0.3.3

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -200,7 +200,7 @@ jobs:
       run: go vet ./...
 
     - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 
     - name: Run staticcheck
       run: staticcheck ./...


### PR DESCRIPTION
This PR pins `staticcheck` to `v0.3.3` because the later versions require Go 1.19