### PR TITLE
Added filter_untranslated feature to localazy

### DIFF
--- a/localazy.go.json
+++ b/localazy.go.json
@@ -2,7 +2,7 @@
   "upload": {
     "type": "json",
     "files": "locales/default.en.json",
-    "features": ["content_as_object", "plural_object"]
+    "features": ["content_as_object", "plural_object", "filter_untranslated"]
   },
   "download": {
     "files": "locales/${fileWithoutExt}.${lang}.json",


### PR DESCRIPTION
Without this feature flag Localazy will fill the missing translations in exported files with the source translation.
This is already done by the Go library so we can add the flag.