### PR TITLE
Added trivy action to scan image after pushed

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -103,6 +103,23 @@ jobs:
         build-args: |
           GOLANG_VERSION=${{ env.GOLANG_VERSION }}
 
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ${{env.IMAGE_TAGS}}
+        format: 'sarif'
+        ignore-unfixed: true
+        vuln-type: 'os,library'
+        severity: 'CRITICAL,HIGH'
+      env:
+        TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        TRIVY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: 'trivy-results.sarif'
+
     - name: Image digest
       run: echo "::notice ::Image digest ${{ steps.docker_build.outputs.digest }}"
 


### PR DESCRIPTION
This PR adds the call to trivy action vulnerability scan. It scans the images for os and library vulnerabilities. A report in Sarif is generated and then upload to GitHub.