### PR TITLE
Updated staticcheck version

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -200,7 +200,7 @@ jobs:
       run: go vet ./...
 
     - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+      run: go install honnef.co/go/tools/cmd/staticcheck@2023.1.3
 
     - name: Run staticcheck
       run: staticcheck ./...


### PR DESCRIPTION
After updating Go to v1.20.3, staticcheck stopped working.
```
-: cannot import "container/list" (unexpected escape sequence in export data), possibly version skew - reinstall package (compile)
-: cannot import "internal/cpu" (unexpected escape sequence in export data), possibly version skew - reinstall package (compile)
-: cannot import "internal/goarch" (unknown bexport format version -1 ), possibly version skew - reinstall package 
-: cannot import "math/bits" (unknown bexport format version -1 ), possibly version skew - reinstall package 
```
This PR updates staticcheck to the latest version.