### PR TITLE
Updates

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -124,12 +124,12 @@ jobs:
           fi
       - id: required
         run: |
-          echo ::set-output name=services::'{${{env.SERVICES}}}'
+          echo services='{${{env.SERVICES}}}' >> $GITHUB_OUTPUT
 
       - name: display string
         run: |
-          echo "::notice ::Requires Postgres: ${{  inputs.requires-postgres }}"
-          echo "::notice ::Requires Cassandra: ${{  inputs.requires-cassandra }}"
+          echo "::notice ::Requires Postgres: ${{ inputs.requires-postgres }}"
+          echo "::notice ::Requires Cassandra: ${{ inputs.requires-cassandra }}"
           echo "::notice ::Requires Redis: ${{ inputs.requires-redis }}"
           echo "::notice ::Requires Vault: ${{ inputs.requires-vault }}"
           echo "::notice ::Requires ClickHouse: ${{ inputs.requires-clickhouse }}"
@@ -161,11 +161,11 @@ jobs:
       LOCALAZY_WRITE_KEY: ${{ secrets.LOCALAZY_WRITE_KEY }}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout Config
-      # Checkout workflow repo to gain access to config files
-      uses: actions/checkout@v2
+      # Checkout workflow repo to gain access to config file
+      uses: actions/checkout@v3
       with:
         repository: toggleglobal/workflows
         path: './tmp'
@@ -185,7 +185,7 @@ jobs:
         git config --global url."git@github.com:toggleglobal".insteadOf https://github.com/toggleglobal
 
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GOLANG_VERSION }}
         check-latest: false

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -190,6 +190,18 @@ jobs:
         go-version: ${{ env.GOLANG_VERSION }}
         check-latest: false
 
+    - name: Install wire
+      run: go install github.com/google/wire/cmd/wire@v0.5.0
+
+    - name: Check Wire
+      run: |
+        find . -type f -name "wire.go" -execdir wire \;
+        if git status --porcelain | grep -q "wire_gen.go"
+        then
+          echo "wire_gen.go is out of date; run wire locally then push your branch again."
+          exit 1
+        fi
+
     - name: Verify dependencies
       run: go mod verify
 


### PR DESCRIPTION
This PR makes a number of minor updates to the `build.go` workflow.

1. Updates `checkout` and `setup-go` actions to use latest versions.
2. Removes the deprecated `set-output` command which is being removed completely at the end of next month.
More info here:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

3. Includes an extra check to verify that any `wire` generated files are up to date.