### PR TITLE
latest vault is no longer

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -65,7 +65,7 @@ jobs:
         }
       VAULT: >-
         "vault": {
-        "image": "vault:latest",
+        "image": "vault:1.13.3",
         "env": {
         "VAULT_ADDR": "http://0.0.0.0:8200",
         "VAULT_DEV_ROOT_TOKEN_ID": "vault-root-token"},


### PR DESCRIPTION
The `latest` tag in vault is no longer there
![image](https://github.com/toggleglobal/workflows/assets/62111676/8a11293a-b7e1-48bb-ac47-9616916582e7)
This is failing the pipelines
```
Starting vault service container
  /usr/bin/docker pull vault:latest
  Error response from daemon: manifest for vault:latest not found: manifest unknown: manifest unknown
  Warning: Docker pull failed with exit code 1, back off 1.119 seconds before retry.
  /usr/bin/docker pull vault:latest
  Error response from daemon: manifest for vault:latest not found: manifest unknown: manifest unknown
  Warning: Docker pull failed with exit code 1, back off 5.425 seconds before retry.
  /usr/bin/docker pull vault:latest
  Error response from daemon: manifest for vault:latest not found: manifest unknown: manifest unknown
  Error: Docker pull failed with exit code 1
```

Freezed the version to 1.13.3