### PR TITLE
Relax required secrets

### DIFF
--- a/.github/workflows/image-go.yml
+++ b/.github/workflows/image-go.yml
@@ -1,18 +1,22 @@
 on:
   workflow_call:
     secrets:
-      DOCKERHUB_USERNAME:
-        required: true
-      DOCKERHUB_TOKEN:
-        required: true
+      # GO_PRIVATE_REPO_KEY is the only secret required for all situations.
+      # The others are only used when 'push-image' input is true; where the
+      # image is actually pushed to Dockerhub and the Infrastructure Chart
+      # is updated with latest tag.
       GO_PRIVATE_REPO_KEY:
         required: true
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
       DEPLOYER_EMAIL:
-        required: true
+        required: false
       DEPLOYER_USERNAME:
-        required: true
+        required: false
       DEPLOYER_GITHUB_TOKEN:
-        required: true
+        required: false
 
     inputs:
       push-image:
@@ -109,6 +113,7 @@ jobs:
         install: true
 
     - name: Login to DockerHub
+      if: inputs.push-image
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
This PR alters the required restriction for most of the secrets of the `image-go` workflow.

When Dependabot creates a PR for a Golang repository that calls the `image-go` workflow, the action fails because it has been initiated by Dependabot. This is because of the security restrictions applied to Dependabot initiated actions which prevent them from accessing the repository secrets; specific Dependabot secrets need to be created instead. 

We could just copy all the repository secrets to Dependabot secrets, however, this isn't the best idea from a security standpoint nor are all the secrets actually needed. The only secret that is _required_ for `image-go` workflow is `GO_PRIVATE_REPO_KEY`; all the other secrets are only needed if/when actually pushing an image and subsequently updating the associated apps-infrastructure Chart tag, and an image push will only occur when a PR is merged to `main` by a team member. A Dependabot initiated action will **never** be responsible for pushing an image*, so the only secret Dependabot _needs_ to supply is `GO_PRIVATE_REPO_KEY` (and Dependabot has this secret already).  

By modifying the `required` setting for this workflow's secrets, it can be used by both Dependabot and "normally initiated" actions. This does mean that the workflow could be called with `push-image` set to `true`, but without the other secrets being supplied; such an action would still fail, but just at a later stage of the process, for example, the step when trying to login to Dockerhub:

```
Logging into Docker Hub...
Error: Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password
```
Instead of when the action is being setup:
```
Secret DOCKERHUB_USERNAME is required, but not provided while calling.
```  
