### PR TITLE
Update Localazy configuration

### DIFF
--- a/localazy.go.json
+++ b/localazy.go.json
@@ -5,7 +5,6 @@
     "features": ["content_as_object", "plural_object", "filter_untranslated"]
   },
   "download": {
-    "files": "locales/${fileWithoutExt}.${lang}.json",
-    "includeSourceLang": true
+    "files": "locales/${fileWithoutExt}.${lang}.json"
   }
 }


### PR DESCRIPTION
This PR removes the `includeSourceLang` option because we don't need it and it can slow down the source language localization.