### PR TITLE
Verify Go file formatting

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -210,9 +210,11 @@ jobs:
         ISSUES=$(goimports -l .)
         has_issues=false
         while read -r issue; do
-          if ! [[ $issue =~ _gen.go$ ]]; then
-            echo "$issue"
-            has_issues=true
+          if [[ -n "$issue" ]]; then
+            if [[ ! $issue =~ _(gen|enumer)\.go$ ]]; then
+              echo "$issue"
+              has_issues=true
+            fi
           fi
         done <<< "$ISSUES"
         if [ "$has_issues" = true ]; then

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -206,7 +206,13 @@ jobs:
       run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Verify formatting
-      run: goimports -d -l .
+      run: |
+        ISSUES=$(goimports -d -l .)
+        if [ -n "$ISSUES" ]; then
+          echo $ISSUES
+          echo "One or more files appeared to be malformatted; run goimports locally then push your branch again."
+          exit 1
+        fi
 
     - name: Verify dependencies
       run: go mod verify

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -202,6 +202,12 @@ jobs:
           exit 1
         fi
 
+    - name: Install goimports
+      run: go install golang.org/x/tools/cmd/goimports@latest
+
+    - name: Verify formatting
+      run: goimports -d -l .
+
     - name: Verify dependencies
       run: go mod verify
 

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -207,9 +207,15 @@ jobs:
 
     - name: Verify formatting
       run: |
-        ISSUES=$(goimports -d -l .)
-        if [ -n "$ISSUES" ]; then
-          echo $ISSUES
+        ISSUES=$(goimports -l .)
+        has_issues=false
+        while read -r issue; do
+          if ! [[ $issue =~ _gen.go$ ]]; then
+            echo "$issue"
+            has_issues=true
+          fi
+        done <<< "$ISSUES"
+        if [ "$has_issues" = true ]; then
           echo "One or more files appeared to be malformatted; run goimports locally then push your branch again."
           exit 1
         fi


### PR DESCRIPTION
This PR adds a code format verification step to the the Go build action.
 
Although the action is already running `go vet` and `staticcheck` (which performs linting too), it seems that neither of these tools actually picks up on bad formatting, as highlighted by [this](https://github.com/toggleglobal/knowledge-graph/pull/11/files#diff-087eeafcce14af5b225984bb1840521f22158e371699dc859eb650dee1deeac9) PR, where the `fmt` import has just been appended to the list instead of being after `context`, and the indentation for of all the new code is with spaces instead of tabs.

The changes in this PR include the addition of 2 new steps; one to install `goimports` and another to call it with the `-l` flag to list files that are not formatted correctly. The workflow fails if incorrectly formatted Go files are found, although common auto generated files (e.g. `wire_gen.go`, `entity_enumer.go`) are excluded from this rule.   
 