### PR TITLE
Ignores the .templates folder from tog

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -207,13 +207,15 @@ jobs:
 
     - name: Verify formatting
       run: |
-        ISSUES=$(goimports -l .)
+        ISSUES=$(goimports -l -e . 2>&1)
         has_issues=false
         while read -r issue; do
           if [[ -n "$issue" ]]; then
-            if [[ ! $issue =~ (_gen|_enumer|\.pb)\.go$ ]]; then
-              echo "$issue"
-              has_issues=true
+            if [[ ! $issue =~ ^\.templates/ ]]; then
+              if [[ ! $issue =~ (_gen|_enumer|\.pb)\.go$ ]]; then
+                echo "$issue"
+                has_issues=true
+              fi
             fi
           fi
         done <<< "$ISSUES"


### PR DESCRIPTION
This PR handles the error where `goimports` checks the `.templates` folder of `tog`.

Although it's a quick and very specific fix, honestly I see no point in creating something more evolved since in the last 100 PRs I saw, this is the only repo I caught a similar error.

- Redirects the `stderr` to `stdout`, because the errors of the `.templates` were `go` issues, so it was exiting with error code 2.
- Adds the `-e` flag to output all the errors and not only the first `10`