### PR TITLE
Exit the "Verify formatting" step with return code 0

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -223,6 +223,7 @@ jobs:
           echo "One or more files appeared to be malformatted; run goimports locally then push your branch again."
           exit 1
         fi
+        exit 0
 
     - name: Verify dependencies
       run: go mod verify


### PR DESCRIPTION
I can't reproduce the issue locally, but I believe it's keeping the return code from the `goimports` command, so I'm forcing the `0`.