### PR TITLE
Fix image website envs

### DIFF
--- a/.github/workflows/image-website.yml
+++ b/.github/workflows/image-website.yml
@@ -80,6 +80,7 @@ jobs:
           IMAGE="${{github.repository}}:$IMAGE_TAG"
           echo "IMAGE=$IMAGE" >> $GITHUB_ENV
           echo "IMAGE=$IMAGE" >> $GITHUB_OUTPUT
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
       - name: Setup SSH
         run: |


### PR DESCRIPTION
IMAGE_TAG env is used to commit new image in values, but it was only in outputs