### PR TITLE
Feature python notify

### DIFF
--- a/.github/workflows/notify-python.yml
+++ b/.github/workflows/notify-python.yml
@@ -7,7 +7,7 @@ on:
         type: string
       jobs:
         description: What jobs needs to notify, like "[build, image]".
-        required: true
+        required: false
         type: string
       include_workflow_status:
         description: Includes the overall workflow conclusion and status of individual jobs.

--- a/.github/workflows/notify-python.yml
+++ b/.github/workflows/notify-python.yml
@@ -1,0 +1,35 @@
+on:
+  workflow_call:
+    inputs:
+      stage:
+        description: Which stage is the notification for, like 'build' or 'pr'.
+        required: true
+        type: string
+      jobs:
+        description: What jobs needs to notify, like "[build, image]".
+        required: true
+        type: string
+      include_workflow_status:
+        description: Includes the overall workflow conclusion and status of individual jobs.
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  notify:
+    name: Notify
+    runs-on: ubuntu-latest
+    needs: ${{ fromJson(inputs.jobs) }}
+    if: always()
+    steps:
+      - name: Set channel
+        id: set-channel
+        run: |
+          echo "channel=${{inputs.stage == 'build' && 'dev-ds-build' || inputs.stage == 'pr' && 'dev-ds-pr'}}" >> $GITHUB_OUTPUT
+      - uses: spaceweasel/slackhub@main
+        with:
+          channel: ${{ steps.set-channel.outputs.channel }}
+          include_workflow_status: ${{ inputs.include_workflow_status }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-python.yml
+++ b/.github/workflows/notify-python.yml
@@ -5,10 +5,6 @@ on:
         description: Which stage is the notification for, like 'build' or 'pr'.
         required: true
         type: string
-      jobs:
-        description: What jobs needs to notify, like "[build, image]".
-        required: false
-        type: string
       include_workflow_status:
         description: Includes the overall workflow conclusion and status of individual jobs.
         required: false
@@ -19,7 +15,6 @@ jobs:
   notify:
     name: Notify
     runs-on: ubuntu-latest
-    needs: ${{ fromJson(inputs.jobs) }}
     if: always()
     steps:
       - name: Set channel

--- a/.github/workflows/notify-python.yml
+++ b/.github/workflows/notify-python.yml
@@ -8,12 +8,12 @@ on:
       include_workflow_status:
         description: Includes the overall workflow conclusion and status of individual jobs.
         required: false
-        default: false
+        default: true
         type: boolean
 
 jobs:
   notify:
-    name: Notify
+    name: Slack Notification
     runs-on: ubuntu-latest
     if: always()
     steps:


### PR DESCRIPTION
Add notify workflow, instead of setting up slack channel directly, we use a variable `stage` to control which channel it will use:

- if `stage` is `build`, use `dev-ds-build ` channel
- if `stage` is `pr`, use `dev-ds-pr ` channel

