### PR TITLE
Skip format check

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -228,11 +228,11 @@ jobs:
         fi
 
     - name: Install goimports
-      if: !inputs.skip-format-check
+      if: ${{ inputs.skip-format-check == false }}
       run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Verify formatting
-      if: !inputs.skip-format-check
+      if: ${{ inputs.skip-format-check == false }}
       run: |
         ISSUES=$(goimports -l -e . 2>&1)
         has_issues=false

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -33,6 +33,11 @@ on:
       requires-manticore:
         type: boolean
         required: false
+      skip-format-check:
+        description: Prevents verification of go file formatting with goimports when set to true. Required until https://github.com/golang/go/issues/42965 is resolved.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   required:
@@ -223,9 +228,11 @@ jobs:
         fi
 
     - name: Install goimports
+      if: !inputs.skip-format-check
       run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Verify formatting
+      if: !inputs.skip-format-check
       run: |
         ISSUES=$(goimports -l -e . 2>&1)
         has_issues=false


### PR DESCRIPTION
This PR adds `skip-format-check` input. This is required to prevent `goimports` running on certain repositories; specifically, [tog](https://github.com/toggleglobal/tog), which fails the format check because of the templated files.

Ideally `goimports` could be configured to ignore certain directories, and although it is supposed to respect items in a  .goimportsignore, this was an old hack which does not work with go modules. Long and old discussion [here](https://github.com/golang/go/issues/42965), but looks like there might be a fix on the horizon.