### PR TITLE
use python tests packages from the project.toml

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -62,7 +62,6 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          poetry add coverage flake8 pytest tox pyright
           poetry install
 
       - name: Lint


### PR DESCRIPTION

The issue to be fixed is:
pytest's latest version is 8.0.0 but pytest-asyncio which is used by many repos are not supporting it yet. if we use 8.0.0 here,  some tests will fail.

so instead of installing latest test dependencies in pipeline, we use test/dev dependencies from pyproject.toml file. 
