### PR TITLE
Remove code coverage gate

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -298,11 +298,7 @@ jobs:
     - name: Run tests
       run: gotestsum --no-color=false -- -race -coverprofile=cover.out -covermode=atomic -vet=off ./...
 
-    - name: Quality Gate
+    - name: Test Coverage
       run: |
         total=`go tool cover -func=cover.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
         echo "Total test coverage = $total%"
-        if (( $(echo "$total ${{ inputs.coverage-threshold }}" | awk '{print ($1 < $2)}') )); then
-          echo "Quality gate failed. Coverage below minimum ${{ inputs.coverage-threshold }}%"
-          exit 1
-        fi

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -300,5 +300,4 @@ jobs:
 
     - name: Test Coverage
       run: |
-        total=`go tool cover -func=cover.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
-        echo "Total test coverage = $total%"
+        go tool cover -func=cover.out


### PR DESCRIPTION
This PR removes the gate for code test coverage.

[Go 1.22](https://tip.golang.org/doc/go1.22) has modified the way coverage is reported:

> go test -cover now prints coverage summaries for covered packages that do not have their own test files. Prior to Go 1.22 a go test -cover run for such a package would report
> ? mymod/mypack [no test files]
> and now with Go 1.22, functions in the package are treated as uncovered:
> mymod/mypack coverage: 0.0% of statements

This means that some repositories that used to meet the coverage threshold are now failing the build.
An example being `article-stats`, which under go 1.21 used to report:

> github.com/toggleglobal/article-stats/pkg/cassdb/store.go:16:                   New             100.0%
> github.com/toggleglobal/article-stats/pkg/cassdb/store.go:22:                   Write           100.0%
> github.com/toggleglobal/article-stats/pkg/cassdb/store.go:45:                   Read            83.3%
> github.com/toggleglobal/article-stats/pkg/domain/service.go:23:                 New             100.0%
> github.com/toggleglobal/article-stats/pkg/domain/service.go:30:                 Write           66.7%
> github.com/toggleglobal/article-stats/pkg/domain/service.go:40:                 Read            100.0%
> github.com/toggleglobal/article-stats/pkg/domain/service.go:44:                 date            100.0%
> github.com/toggleglobal/article-stats/pkg/http/handler.go:26:                   NewHandler      100.0%
> github.com/toggleglobal/article-stats/pkg/http/handler.go:33:                   GetStats        60.0%
> github.com/toggleglobal/article-stats/pkg/http/handler.go:44:                   newArticleStats 100.0%
> github.com/toggleglobal/article-stats/pkg/http/router.go:9:                     NewRouter       0.0%
> github.com/toggleglobal/article-stats/pkg/kafka/listener/listener.go:18:        Register        0.0%
> github.com/toggleglobal/article-stats/pkg/kafka/listener/listener.go:39:        New             100.0%
> github.com/toggleglobal/article-stats/pkg/kafka/listener/listener.go:46:        HandleMessage   66.7%
> github.com/toggleglobal/article-stats/pkg/kafka/listener/listener.go:56:        newDomainStats  100.0%
> total:                                                                          (statements)    71.1%

Burt now reports:

> github.com/toggleglobal/article-stats/cmd/article-stats/main.go:5:              main            0.0%
> github.com/toggleglobal/article-stats/cmd/article-stats/service.go:15:          NewService      0.0%
> github.com/toggleglobal/article-stats/cmd/article-stats/wire_gen.go:27:         Setup           0.0%
> github.com/toggleglobal/article-stats/pkg/cassdb/store.go:16:                   New             100.0%
> github.com/toggleglobal/article-stats/pkg/cassdb/store.go:22:                   Write           100.0%
> github.com/toggleglobal/article-stats/pkg/cassdb/store.go:45:                   Read            83.3%
> github.com/toggleglobal/article-stats/pkg/domain/service.go:23:                 New             100.0%
> github.com/toggleglobal/article-stats/pkg/domain/service.go:30:                 Write           66.7%
> github.com/toggleglobal/article-stats/pkg/domain/service.go:40:                 Read            100.0%
> github.com/toggleglobal/article-stats/pkg/domain/service.go:44:                 date            100.0%
> github.com/toggleglobal/article-stats/pkg/http/handler.go:26:                   NewHandler      100.0%
> github.com/toggleglobal/article-stats/pkg/http/handler.go:33:                   GetStats        60.0%
> github.com/toggleglobal/article-stats/pkg/http/handler.go:44:                   newArticleStats 100.0%
> github.com/toggleglobal/article-stats/pkg/http/router.go:9:                     NewRouter       0.0%
> github.com/toggleglobal/article-stats/pkg/kafka/listener/listener.go:18:        Register        0.0%
> github.com/toggleglobal/article-stats/pkg/kafka/listener/listener.go:39:        New             100.0%
> github.com/toggleglobal/article-stats/pkg/kafka/listener/listener.go:46:        HandleMessage   66.7%
> github.com/toggleglobal/article-stats/pkg/kafka/listener/listener.go:56:        newDomainStats  100.0%
> total:                                                                          (statements)    25.7%

Various options are available to us:

#### Option A
Adjust/drop the threshold to cater for the change.
This gives a much better and more realistic/accurate result of what the coverage actually is. After all, if you just included a single file with a single function:
```go
func Check()bool{
  return true
} 
``` 
and had a corresponding test file that validated the function, coverage would report 100%. However, right now we’d need to drop the default threshold, but as many repos override the threshold, we’d need to modify a lot of repositories too.

#### Option B
Use a flag to revert the behaviour:
```shell
GOEXPERIMENT=nocoverageredesign gotestsum --no-color=false -- -race -coverprofile=cover.out -covermode=atomic -vet=off ./...
```
This is a quick change as it maintains what we had, but I’m not keen on having this flag hanging around forever and would prefer to use “standard” invocation where possible.

#### Option C
Stop using the coverage as a gate; just report what the coverage is and continue.
This seems like the best approach for the moment. We have never _not_ deployed something because it didn’t meet the threshold; on the contrary, we just drop the threshold to get it through, so not really any point having this as a gate. 

#### Decision
Option C
