### PR TITLE
Deprecated actions

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -186,11 +186,11 @@ jobs:
       LOCALAZY_WRITE_KEY: ${{ secrets.LOCALAZY_WRITE_KEY }}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checkout Config
       # Checkout workflow repo to gain access to config file
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: toggleglobal/workflows
         path: './tmp'
@@ -215,7 +215,7 @@ jobs:
         git config --global url."git@github.com:toggleglobal".insteadOf https://github.com/toggleglobal
 
     - name: Setup Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOLANG_VERSION }}
         check-latest: false

--- a/.github/workflows/image-go.yml
+++ b/.github/workflows/image-go.yml
@@ -65,11 +65,11 @@ jobs:
       LOCALAZY_READ_KEY: ${{ secrets.LOCALAZY_READ_KEY }}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checkout Config
       # Checkout workflow repo to gain access to config files
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: toggleglobal/workflows
         path: './tmp'
@@ -108,13 +108,13 @@ jobs:
         ssh-add - <<< "${{ secrets.GO_PRIVATE_REPO_KEY }}"
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         install: true
 
     - name: Login to DockerHub
       if: inputs.push-image
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -134,7 +134,7 @@ jobs:
 
     - name: Build image and push to Docker Hub
       id: docker_build
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v5
       with:
         context: .
         file: ${{ inputs.dockerfile }}
@@ -160,7 +160,7 @@ jobs:
         TRIVY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Upload Trivy Reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: inputs.push-image
       with:
         name: Security Report
@@ -169,7 +169,7 @@ jobs:
 
     - name: Checkout Workflows Repo
       if: inputs.push-image
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: "toggleglobal/workflows"
         token: ${{ secrets.DEPLOYER_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the versions of many of the actions called in golang related workflows which were using [deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) versions.
![image](https://github.com/toggleglobal/workflows/assets/73553594/52bf9805-c833-4e6b-a365-2412f84f2859)

