### PR TITLE
Set manticore to v6.2.12

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -88,7 +88,7 @@ jobs:
         }
       MANTICORE: >-
         "manticore": {
-        "image": "manticoresearch/manticore",
+        "image": "manticoresearch/manticore:6.2.12",
         "ports":["9306:9306"],
         "options": "--health-cmd \"searchd --status\" --health-interval 10s --health-timeout 5s --health-retries 5"
         }


### PR DESCRIPTION
Manticore was set to use the latest version. Building the search service is failing after a new version (6.3.0) released on 2024-5-23. Rolling back the version to hopefully fix the build.