### PR TITLE
Removes the build step in build-go

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -158,7 +158,7 @@ jobs:
           echo "::notice ::Requires Manticore: ${{ inputs.requires-manticore }}"
 
   build:
-    name: Build & Test
+    name: Build (not) & Test
     runs-on: ubuntu-latest
     needs: required
     services: ${{fromJSON(needs.required.outputs.services)}}
@@ -259,9 +259,6 @@ jobs:
 
     - name: Verify dependencies
       run: go mod verify
-
-    - name: Build
-      run: go build -v ./...
 
     - name: Run go vet
       run: go vet ./...

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -158,7 +158,7 @@ jobs:
           echo "::notice ::Requires Manticore: ${{ inputs.requires-manticore }}"
 
   build:
-    name: Build (not) & Test
+    name: Build & Test
     runs-on: ubuntu-latest
     needs: required
     services: ${{fromJSON(needs.required.outputs.services)}}


### PR DESCRIPTION
I appreciate it makes very little sense to have a build workflow without the build step, but it is a duplicated process and it takes too long.
