### PR TITLE
Update build-go postgres to v16.2

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       POSTGRES: >-
         "postgres": {
-        "image": "postgres:11.4",
+        "image": "postgres:16.2",
         "env": {
         "POSTGRES_DB": "postgres",
         "POSTGRES_USER": "postgres",


### PR DESCRIPTION
This PR updates postgres version used for go-build testing to match deployment environments.
This version allows use of the build in [`gen_random_uuid()`](https://www.postgresql.org/docs/current/functions-uuid.html) (available since v13) alleviating us from the need to create/check the `uuid-ossp` extension and avoid the associated issues.