### PR TITLE
Add skip dirs parameter for Trivy scanner

### DIFF
--- a/.github/workflows/image-python.yml
+++ b/.github/workflows/image-python.yml
@@ -62,6 +62,11 @@ on:
         default: false
         required: false
         type: boolean
+      trivy-skip-dirs:
+        description: Comma separated list of directories where traversal is skipped
+        required: false
+        default: ''
+        type: string
     outputs:
       image-tag:
         value: ${{ jobs.build-push-image.outputs.image-tag }}
@@ -177,6 +182,7 @@ jobs:
     uses: toggleglobal/workflows/.github/workflows/vulnerability-scanner.yml@main
     with:
       image: ${{ needs.build-push-image.outputs.image-ref }}
+      skip-dirs: ${{ inputs.trivy-skip-dirs }}
 
   update-app-chart:
     needs: [ build-push-image, scan-image ]

--- a/.github/workflows/vulnerability-scanner.yml
+++ b/.github/workflows/vulnerability-scanner.yml
@@ -12,6 +12,11 @@ on:
         description: The image that needs to be scanned
         required: true
         type: string
+      skip-dirs:
+        description: Comma separated list of directories where traversal is skipped
+        required: false
+        default: ''
+        type: string
 
 jobs:
   scan-image:
@@ -25,6 +30,7 @@ jobs:
           output: trivy-results.json
           timeout: 10m
           ignore-unfixed: true
+          skip-dirs: ${{ inputs.skip-dirs }}
         env:
           TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           TRIVY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Trivy action will fail on docker images with large files, as a temporary workaround we should have solution to ignore this files